### PR TITLE
Updated the URM creation section

### DIFF
--- a/Utils/dataset.py
+++ b/Utils/dataset.py
@@ -394,8 +394,8 @@ class ContentWiseImpressions(Dataset):
 
         self.URM = {
             "train": train_split,
-            "test": validation_split,
-            "validation": test_split
+            "validation": validation_split,
+            "test": test_split,
         }
 
     def _generate_urm_impressions(self, use_items: bool) -> None:


### PR DESCRIPTION
The `validation` and `test` splits were erroneously assigned. This caused the script to load the `test` split when asking for the validation and vice versa.

Fixes issue #5 